### PR TITLE
Refine CI workflow for Android builds with intelligent strategy: enab…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
           echo "  - Services : $(find src/services -name "*.ts" | wc -l)"
 
   # Job de build Android
+  # Stratégie intelligente : Debug sur toutes les branches, Release seulement sur main
   build-android:
     name: Build Android
     runs-on: ubuntu-latest
@@ -104,7 +105,10 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        build-type: [debug, release]
+        build-type: [debug]
+        include:
+          - build-type: release
+            condition: ${{ github.ref == 'refs/heads/main' }}
 
     steps:
       - name: Checkout du code source
@@ -169,7 +173,7 @@ jobs:
           echo "✅ Build Android Debug réussi"
 
       - name: Build Android Release
-        if: matrix.build-type == 'release'
+        if: matrix.build-type == 'release' && github.ref == 'refs/heads/main'
         run: |
           cd android
           chmod +x ./gradlew
@@ -184,6 +188,8 @@ jobs:
             android/app/build/outputs/apk/${{ matrix.build-type }}/*.apk
             android/app/build/outputs/bundle/${{ matrix.build-type }}/*.aab
           retention-days: 30
+        # Upload conditionnel : Release seulement sur main
+        if: matrix.build-type == 'debug' || (matrix.build-type == 'release' && github.ref == 'refs/heads/main')
 
     # Job de build iOS (Désactivé pour la version actuelle)
   build-ios:

--- a/doc/CI_CD_GUIDE.md
+++ b/doc/CI_CD_GUIDE.md
@@ -43,7 +43,12 @@ Le pipeline CI/CD se déclenche automatiquement dans les situations suivantes :
 
 ### 2. Build Android (`build-android`)
 
-**Objectif** : Compilation des applications Android (Debug et Release)
+**Objectif** : Compilation des applications Android avec stratégie intelligente
+
+**Stratégie de Build** :
+
+- **Debug** : Sur toutes les branches (développement)
+- **Release** : Seulement sur la branche `main` (production)
 
 **Étapes** :
 
@@ -51,12 +56,15 @@ Le pipeline CI/CD se déclenche automatiquement dans les situations suivantes :
 - Installation des dépendances Node.js
 - Configuration des variables d'environnement Android
 - Cache des dépendances Gradle et npm
-- Build des APKs et AABs
-- Upload des artefacts
+- Build des APKs et AABs (conditionnel)
+- Upload des artefacts (conditionnel)
 
-**Durée estimée** : 45 minutes
-**Runner** : `ubuntu-latest`
-**Dépendances** : `validate-and-test`
+**Durée estimée** :
+
+- **Debug uniquement** : 15-20 minutes (branches de dev)
+- **Debug + Release** : 35-45 minutes (branche main)
+  **Runner** : `ubuntu-latest`
+  **Dépendances** : `validate-and-test`
 
 ### 3. Build iOS (`build-ios`) - Temporairement Désactivé
 
@@ -208,15 +216,25 @@ Chaque job dispose de timeouts spécifiques pour éviter les blocages :
 
 ## Stratégie de Build
 
-### Build Matrix
+### Build Matrix Intelligente
 
-Le pipeline utilise des matrices de build pour optimiser la compilation :
+Le pipeline utilise une stratégie de build intelligente pour optimiser les coûts et le temps :
 
 ```yaml
 strategy:
   matrix:
-    build-type: [debug, release]
+    build-type: [debug]
+    include:
+      - build-type: release
+        condition: ${{ github.ref == 'refs/heads/main' }}
 ```
+
+**Avantages de cette approche :**
+
+- **Debug** : Sur toutes les branches (développement rapide)
+- **Release** : Seulement sur `main` (production validée)
+- **Économie** : ~50% de temps de build sur les branches de dev
+- **Coût** : Gratuit pour les repos publics (GitHub Actions)
 
 ### Conditions de Déploiement
 


### PR DESCRIPTION
…le Debug builds on all branches and restrict Release builds to the main branch. Update documentation to reflect new build strategy and conditions for artifact uploads.